### PR TITLE
Updates deploy example to use package homepage URL

### DIFF
--- a/index.md
+++ b/index.md
@@ -202,13 +202,14 @@ Add the following to your package.json:
 
 ```json
 {
+  "homepage": "http://example.com",
   "scripts": {
     "start": "jus serve",
     "deploy": "npm run build && npm run commit && npm run push && npm run open",
     "build": "jus build . dist",
     "commit": "git add dist && git commit -m 'update dist'",
     "push": "git subtree push --prefix dist origin gh-pages",
-    "open": "open http://zeke.sikelianos.com"
+    "open": "open $npm_package_homepage"
   }
 }
 ```
@@ -239,12 +240,13 @@ Add the following to your package.json:
 
 ```json
 {
+  "homepage": "http://example.com",
   "scripts": {
     "start": "jus serve",
     "deploy": "npm run build && npm run build && npm run open",
     "build": "jus build . dist",
-    "push": "surge dist YOUR-URL",
-    "open": "open YOUR-URL"
+    "push": "surge dist $npm_package_homepage",
+    "open": "open $npm_package_homepage"
   }
 }
 ```


### PR DESCRIPTION
Totally optional, but I think this is a nice way to specify the URL for GitHub Pages or Surge deployments. Nice work on Jus! Trying it out for some docs on something new and it’s working really well so far, I’ll let you know when it’s live.