### PR TITLE
Hopefully fix missing {{{body}}} from Templates section

### DIFF
--- a/index.md
+++ b/index.md
@@ -121,7 +121,7 @@ Note: Jekyll uses YAML for frontmatter, but jus uses HTML, because it can be inc
 Handlebars templates can be used to wrap layouts around your pages.
 
 - If a file named `/layout.(html|hbs|handlebars|markdown|md)` is present, it will be applied to all pages by default.
-- Templates must include a `{{{body}}}` string, to be used as a placeholder for where the main content should be rendered.
+- Templates must include a <code>&lcub;&lcub;&lcub;body&rcub;&rcub;&rcub;</code> string, to be used as a placeholder for where the main content should be rendered.
 - Templates must have the word `layout` in their filename.
 - Pages can specify a custom layout in their [frontmatter](#frontmatter). Specifying `layout: foo` will refer to the `/layout-foo.(html|hbs|handlebars|markdown|md)` layout file.
 - Pages can disable layout by setting `layout: false` in their frontmatter.


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/587740/18420335/774dccca-783e-11e6-854b-5da4d9de6fee.png)

I remember thinking "Well, OK, that's not super descriptive" at the time. Only later after I started using zeke.sikelianos.com as a reference did it occur to me to check the source for jus.js.org, and there it is. The string '{{{body}}}' somehow got stripped. Honestly, this is probably a bug in `jus` but mangling the docs seemed easier.

I also don't really know if this patch fixes it or not; I just blindly edited it in Github's Markdown editor without testing it. But I figured that is more helpful than just filing a bug report.