### PR TITLE
use `overflow: auto` to avoid always-present scrollbar in nav

### DIFF
--- a/styles/index.styl
+++ b/styles/index.styl
@@ -107,7 +107,7 @@ nav
   color white
   font-weight 300
   padding-top 40px
-  overflow-y scroll
+  overflow-y auto
   a
     color white
     display block


### PR DESCRIPTION
## before
![](https://cloud.githubusercontent.com/assets/203725/20091729/2e514b72-a549-11e6-80bf-fe5e7a8181dd.png)

## after
![](https://cloud.githubusercontent.com/assets/203725/20091751/4ae8f3fc-a549-11e6-87c3-0fd74bc7cb74.png)
![](https://cloud.githubusercontent.com/assets/203725/20091755/5444e6d6-a549-11e6-8b9c-5fa80154cd69.png)
